### PR TITLE
Fix when adding a long attachment file name, jira server return 500.

### DIFF
--- a/bzjira/__main__.py
+++ b/bzjira/__main__.py
@@ -60,6 +60,10 @@ def sync_new_jira_to_jira(new_jira_server, new_jira, bug, jira, project_key, yes
         filename = '{}-{}{}'.format(root, a.id, ext)
         import urllib.request, urllib.error, urllib.parse
         filename = urllib.parse.quote(filename.encode('utf-8'))
+        if len(filename) >= 255:
+            ext_len = len(ext)
+            filename = filename[:255-ext_len] + ext
+            print('Filename too long, truncate to 255')
         if find_attachement(filename):
             continue
         jira.add_attachment(issue, BytesIO(a.get()), filename)


### PR DESCRIPTION
Solution: ensure filename is at most 255 by truncating filename

Sample response:
jira.exceptions.JIRAError: JiraError HTTP 500 url: http://qcloud-jira.qnap.com.tw:8080/rest/api/2/issue/INF-4126/attachments
	text: org.ofbiz.core.entity.GenericEntityException: while inserting: [GenericEntity:FileAttachment][filename,VERYLONG.png][issue,86321][author,robot][created,2019-09-18 10:36:52.242][mimetype,image/png][filesize,646792][id,42606] (SQL Exception while executing the following:INSERT INTO fileattachment (ID, issueid, MIMETYPE, FILENAME, CREATED, FILESIZE, AUTHOR, zip, thumbnailable) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) (Data truncation: Data too long for column 'FILENAME' at row 1))